### PR TITLE
feat/22-common-response-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,10 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // swagger ui
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/example/homeaid/global/common/response/ApiResponse.java
+++ b/src/main/java/com/example/homeaid/global/common/response/ApiResponse.java
@@ -1,0 +1,34 @@
+package com.example.homeaid.global.common.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(staticName = "of")
+public class ApiResponse<T> {
+
+  private boolean success;
+
+  private T data;
+
+  private String code;
+
+  private String message;
+
+  public static <T> ApiResponse<T> success(T data) {
+    return ApiResponse.of(true, data, "SUCCESS", "요청이 성공했습니다.");
+  }
+
+  public static ApiResponse<Void> success() {
+    return ApiResponse.of(true, null, "SUCCESS", "요청이 성공했습니다.");
+  }
+
+  public static ApiResponse<Void> fail(String code, String message) {
+    return ApiResponse.of(false, null, code, message);
+  }
+
+
+}

--- a/src/main/java/com/example/homeaid/global/common/response/ApiResponse.java
+++ b/src/main/java/com/example/homeaid/global/common/response/ApiResponse.java
@@ -1,21 +1,27 @@
 package com.example.homeaid.global.common.response;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "공통 API 응답 포맷")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor(staticName = "of")
 public class ApiResponse<T> {
 
+  @Schema(description = "성공 여부", example = "true")
   private boolean success;
 
+  @Schema(description = "응답 데이터", nullable = true)
   private T data;
 
+  @Schema(description = "응답 코드", example = "SUCCESS", nullable = true)
   private String code;
 
+  @Schema(description = "응답 메시지", example = "요청이 성공했습니다.", nullable = true)
   private String message;
 
   public static <T> ApiResponse<T> success(T data) {

--- a/src/main/java/com/example/homeaid/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/homeaid/global/config/SwaggerConfig.java
@@ -1,0 +1,21 @@
+package com.example.homeaid.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI springOpenAPI() {
+
+    return new OpenAPI()
+        .info(new Info()
+            .title("HomeAid API 명세서")
+            .version("1.0")
+            .description("HomeAid는 매칭시스템을 활용하여 고객에게 맞춤형 매니저를 매칭시켜주고 가사 및 청소 서비스를 제공합니다."));
+
+  }
+}

--- a/src/main/java/com/example/homeaid/global/exception/BaseErrorCode.java
+++ b/src/main/java/com/example/homeaid/global/exception/BaseErrorCode.java
@@ -1,0 +1,13 @@
+package com.example.homeaid.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+
+  HttpStatus getStatus(); // HTTP 상태코드 반환
+
+  String getCode(); // 프론트에 보여줄 오류 코드
+
+  String getMessage(); // 사용자에게 보여줄 메시지
+
+}

--- a/src/main/java/com/example/homeaid/global/exception/CustomException.java
+++ b/src/main/java/com/example/homeaid/global/exception/CustomException.java
@@ -1,0 +1,15 @@
+package com.example.homeaid.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public CustomException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+}

--- a/src/main/java/com/example/homeaid/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/homeaid/global/exception/ErrorCode.java
@@ -1,0 +1,38 @@
+package com.example.homeaid.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode implements BaseErrorCode {
+
+  // 400 BAD REQUEST
+  INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "잘못된 요청입니다."),
+  VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "요청 값이 올바르지 않습니다."),
+
+  // 401 UNAUTHORIZED
+  UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다."),
+
+  // 403 FORBIDDEN
+  FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "접근 권한이 없습니다."),
+
+  // 404 NOT FOUND
+  RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE_NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
+
+  // 405 METHOD NOT ALLOWED
+  METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "METHOD_NOT_ALLOWED", "허용되지 않은 HTTP 메서드입니다."),
+
+  // 409 CONFLICT
+  DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "DUPLICATE_RESOURCE", "중복된 리소스입니다."),
+
+  // 500 INTERNAL SERVER ERROR
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR",
+      "서버 오류가 발생했습니다.");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+
+}

--- a/src/main/java/com/example/homeaid/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/homeaid/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,53 @@
+package com.example.homeaid.global.exception;
+
+import com.example.homeaid.global.common.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+
+  @ExceptionHandler(CustomException.class)
+  public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
+    log.warn("[CustomException] {} - {}", e.getErrorCode().getCode(), e.getMessage());
+
+    return ResponseEntity.status(e.getErrorCode().getStatus())
+        .body(ApiResponse.fail(e.getErrorCode().getCode(), e.getErrorCode().getMessage()));
+  }
+
+  /**
+   * DTO 유효성 검증 실패
+   */
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
+    String message = e.getBindingResult().getFieldErrors().stream()
+        .findFirst()
+        .map(DefaultMessageSourceResolvable::getDefaultMessage)
+        .orElse("입력값이 올바르지 않습니다.");
+
+    log.warn("[ValidationException] {}", message);
+
+    return ResponseEntity.badRequest()
+        .body(ApiResponse.fail("VALIDATION_ERROR", message));
+  }
+
+  /**
+   * 요청 JSON 파싱 실패
+   */
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ApiResponse<Void>> handleParsingException(HttpMessageNotReadableException e) {
+    log.warn("[HttpMessageNotReadableException] {}", e.getMessage());
+
+    return ResponseEntity.badRequest()
+        .body(ApiResponse.fail("INVALID_JSON", "요청 형식이 잘못되었습니다."));
+  }
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,20 @@ spring:
 
 env:
   secure-cookie: false
+
+springdoc:
+  api-docs:
+    groups:
+      enabled: true
+
+  swagger-ui:
+    path: /swagger-ui.html
+    enabled: true
+    groups-order: asc
+    tags-sorter: alpha
+    operations-sorter: alpha
+    # try it out 기능에 요청이 수행되는 소요시간을 표시
+    display-request-duration: true
+    # 문서를 로드할때 기본적으로 API가 모두 접힌 상태로 설정
+    # list: 태그만 펼침, full: 모든 API 펼침
+    doc-expansion: none


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 공통 예외 처리와 응답 포맷을 통일하여 API 일관성을 확보하고자 합니다.
- Swagger(OpenAPI)를 적용하여 API 명세 자동화를 구축했습니다.

## ✏️ 변경 사항
- CustomException 및 BaseErrorCode 기반의 예외 처리 구조 도입
- GlobalExceptionHandler를 통한 전역 예외 처리 적용
- ApiResponse<T>를 통한 성공/실패 응답 포맷 통일
- ErrorCode enum을 활용한 공통 에러 코드 관리
- Swagger(OpenAPI 3) 설정 추가 및 기본 API 문서화


## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하나요?
- [x] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [x] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #22